### PR TITLE
Fix layout frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/code.ts
+++ b/code.ts
@@ -35,6 +35,8 @@ figma.ui.onmessage = async (msg: { type: string; headline?: string; size?: 'IG F
         const briefingLayout: FrameNode = figma.createFrame();
         briefingLayout.name = "Briefing";
         // Additional properties like layout mode, sizing mode, and item spacing
+        briefingLayout.appendChild(headlineText);
+        briefingLayout.appendChild(captionText);
 
         // Determine design component dimensions and create it
         let designWidth: number, designHeight: number;
@@ -55,6 +57,8 @@ figma.ui.onmessage = async (msg: { type: string; headline?: string; size?: 'IG F
         const mainLayout: FrameNode = figma.createFrame();
         mainLayout.name = "Main Layout";
         // Additional properties for layout, padding, and corner radius
+        mainLayout.appendChild(briefingLayout);
+        mainLayout.appendChild(designComponent);
 
         // If a node is selected, add an instance of the Design component to it
         const selectedNode: FrameNode | undefined = figma.currentPage.selection[0] as FrameNode;


### PR DESCRIPTION
## Summary
- ensure Headline and Caption are placed within the briefing layout
- append the briefing layout and design component to the main layout
- ignore `node_modules`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840aad19a78832d98d0fa68dd2dfc6f